### PR TITLE
Change "markers" type to JSON_ARRAY

### DIFF
--- a/Lottie/Plugin/LottiePlugin/src/LottieOutputWriter.cpp
+++ b/Lottie/Plugin/LottiePlugin/src/LottieOutputWriter.cpp
@@ -1435,7 +1435,7 @@ namespace LottieExporter
 	FCM::Result JSONOutputWriter::AddMarkers(JSONNode &firstNode)
 	{
        // std::cout<<"ENTERED markers"<<std::endl;
-		JSONNode c;
+		JSONNode c = JSONNode(JSON_ARRAY);
 		c.set_name("markers");
 		firstNode.push_back(c);
 		return FCM_SUCCESS;


### PR DESCRIPTION
I ran into problems trying to import a Lottie JSON produced by the Animate plugin on iOS because the "markers" key was encoded as an empty Object, but the Lottie iOS decoder is quite strict and expects an Array value.